### PR TITLE
fix param typo of Prototype.is.equal

### DIFF
--- a/src/ty/type.js
+++ b/src/ty/type.js
@@ -180,7 +180,7 @@ export class Type {
       }
     }
     // check single value
-    else if (!Prototype.is(value).equal(pattern)) {
+    else if (!Prototype.is(pattern).equal(value)) {
       tyerr.replace({ type: 'exception', value, name: 'equal', pattern })
     }
 


### PR DESCRIPTION
`Prototype.is()` should accept a `Pattern` and `.equal()` should accept a `Value`

the tests didn't cover it because `.equal()` is to `return pattern === value`

it would't throw errors even if you switch these two

lol~

@tangshuang 